### PR TITLE
Support address family preference in endpoint selection

### DIFF
--- a/Scripts/IPParser.cs
+++ b/Scripts/IPParser.cs
@@ -1,9 +1,8 @@
-﻿using System;
+using System;
+using System.Globalization;
 using System.Linq;
-using System.Net.NetworkInformation;
 using System.Net;
 using System.Net.Sockets;
-using System.Globalization;
 
 namespace JimmysUnityUtilities
 {
@@ -12,11 +11,11 @@ namespace JimmysUnityUtilities
         /// <summary>
         /// Like <see cref="ParseEndpoint(string, int)"/> but with graceful failure handling.
         /// </summary>
-        public static bool TryParseEndpoint(string source, int defaultPort, out IPEndPoint endpoint)
+        public static bool TryParseEndpoint(string source, int defaultPort, out IPEndPoint endpoint, AddressFamily? preferredAddressType = null)
         {
             try
             {
-                endpoint = ParseEndpoint(source, defaultPort);
+                endpoint = ParseEndpoint(source, defaultPort, preferredAddressType);
                 return true;
             }
             catch
@@ -30,7 +29,7 @@ namespace JimmysUnityUtilities
         /// Parse a string that refers to an IP endpoint in the format ip:port or [ip]:port (for IPv6). This is the kind of string a user might enter to connect to the server.
         /// </summary>
         /// <param name="defaultPort">The port that will be returned if <paramref name="address"/> does not contain a port.</param>
-        public static IPEndPoint ParseEndpoint(string source, int defaultPort)
+        public static IPEndPoint ParseEndpoint(string source, int defaultPort, AddressFamily? preferredAddressType = null)
         {
             int addressLength = source.Length;
             int lastColonIndex = source.LastIndexOf(':');
@@ -50,7 +49,7 @@ namespace JimmysUnityUtilities
             }
 
             string addressString = source.Substring(0, addressLength);
-            IPAddress address = ParseAddress(addressString);
+            IPAddress address = ParseAddress(addressString, preferredAddressType);
 
             int port = defaultPort;
             if (source.Length > addressLength)
@@ -62,11 +61,11 @@ namespace JimmysUnityUtilities
         /// <summary>
         /// Like <see cref="ParseAddress(string)"/> but with graceful failure handling.
         /// </summary>
-        public static bool TryParseAddress(string ip, out IPAddress ipAddress)
+        public static bool TryParseAddress(string ip, out IPAddress ipAddress, AddressFamily? preferredAddressType = null)
         {
             try
             {
-                ipAddress = ParseAddress(ip);
+                ipAddress = ParseAddress(ip, preferredAddressType);
                 return true;
             }
             catch
@@ -84,7 +83,7 @@ namespace JimmysUnityUtilities
         /// lookup (dotnet doesn't let you change this). Therefore, this method should be run asynchronously when
         /// possible.
         /// </remarks>
-        public static IPAddress ParseAddress(string ip)
+        public static IPAddress ParseAddress(string ip, AddressFamily? preferredAddressType = null)
         {
             if (ip == "localhost")
             {
@@ -107,15 +106,13 @@ namespace JimmysUnityUtilities
             try
             {
                 var hostEntry = Dns.GetHostEntry(ip); // This will time out after 5 seconds (not configurable)
-                foreach (var address in hostEntry.AddressList)
-                {
-                    if (address.AddressFamily == AddressFamily.InterNetwork || address.AddressFamily == AddressFamily.InterNetworkV6)
-                        return address;
-                }
+                var validResults = hostEntry.AddressList
+                    .Where(a => a.AddressFamily == AddressFamily.InterNetwork || a.AddressFamily == AddressFamily.InterNetworkV6)
+                    .OrderByDescending(address => address.AddressFamily == preferredAddressType ? 1 : 0).ToArray();
+                if (validResults.Length > 0)
+                    return validResults[0];
             }
-            catch (SocketException)
-            {
-            }
+            catch (SocketException) { }
 
             throw new Exception("Failed to resolve host");
         }

--- a/Scripts/Networking/Pings/NetworkPinger.cs
+++ b/Scripts/Networking/Pings/NetworkPinger.cs
@@ -32,7 +32,8 @@ namespace JimmysUnityUtilities.Networking.Pings
         Action<PingSuccess> PingSuccessCallback;
         Action<PingFailure> PingFailureCallback;
 
-        public void SendPing(Action<PingSuccess> onPingSuccessCallback, Action<PingFailure> onPingFailureCallback, int numberOfSeparatePings = 10, int timeOutMilliseconds = 5000)
+        public void SendPing(Action<PingSuccess> onPingSuccessCallback, Action<PingFailure> onPingFailureCallback, AddressFamily? preferredAddressType = null,
+            int numberOfSeparatePings = 10, int timeOutMilliseconds = 5000)
         {
             if (numberOfSeparatePings < 1)
                 throw new ArgumentException("Must be at least one", nameof(numberOfSeparatePings));
@@ -52,7 +53,7 @@ namespace JimmysUnityUtilities.Networking.Pings
                 {
                     try
                     {
-                        TargetAddress = IPParser.ParseAddress(HostNameOrAddress);
+                        TargetAddress = IPParser.ParseAddress(HostNameOrAddress, preferredAddressType);
                     }
                     catch
                     {


### PR DESCRIPTION
Essentially you can now supply an AddressFamily value that lets you choose between preferring IPv4 or IPv6 results during DNS lookup.

This is a breaking change due to the argument order of the method NetworkPinger#SendPing().